### PR TITLE
Dev scripts: unified startup for backend and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "dev": "node run.js"
+  }
+}

--- a/run.js
+++ b/run.js
@@ -1,0 +1,16 @@
+const { exec } = require("child_process");
+const path = require("path");
+
+exec("cd backend/T8 && dotnet run", { detached: true });
+
+setTimeout(() => {
+    const file = path.join(__dirname, "frontend", "index.html");
+    const command =
+        process.platform === "win32"
+            ? `start "" "${file}"`
+            : process.platform === "darwin"
+            ? `open "${file}"`
+            : `xdg-open "${file}"`;
+
+    exec(command);
+}, 2000);


### PR DESCRIPTION
# Summary
This pull request adds a simple Node-based development script that starts the backend and opens the frontend automatically. The goal is to streamline local testing and reduce manual steps during development.

Closes - #13 

# Scope
- Added `run.js` script in the project root.
- Script starts the backend using `dotnet run`.
- After a short delay, it opens `frontend/index.html` in the default browser.
- Cross‑platform support (Windows, macOS, Linux) using built‑in Node commands.
- No changes to backend or frontend logic.

# Files Added
- `run.js`
